### PR TITLE
update dependency versions for compatibility with recent breeze versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,12 +9,13 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies  ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % "test",
-  "org.scalactic" %% "scalactic" % "3.2.9" % "test",
-  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % "test",
-  "org.scalanlp" %% "breeze" % "2.0",
-  "org.scalanlp" %% "breeze-viz" % "2.0",
-  "org.scalanlp" %% "breeze-natives" % "2.0",
+  "org.scalatest" %% "scalatest" % "3.2.14" % "test",
+  "org.scalactic" %% "scalactic" % "3.2.14" % "test",
+  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % "test",
+  "org.scalanlp" %% "breeze" % "2.1.0",
+  "org.scalanlp" %% "breeze-viz" % "2.1.0",
+  "org.scalanlp" %% "breeze-natives" % "2.1.0",
+  "dev.ludovic.netlib" % "blas" % "3.0.3" withSources(),
   ("org.ddahl" %% "rscala" % "3.2.19").cross(CrossVersion.for3Use2_13)
 )
 
@@ -31,9 +32,9 @@ resolvers ++= Seq(
     "https://oss.sonatype.org/content/repositories/releases/"
 )
 
-scalaVersion := "3.0.1"
+scalaVersion := "3.2.1"
 
-crossScalaVersions := Seq("2.12.12", "2.13.7", "3.0.1")
+crossScalaVersions := Seq("2.12.17", "2.13.10", "3.2.1")
 
 ThisBuild / versionScheme := Some("strict")
 

--- a/examples/.bsp/sbt.json
+++ b/examples/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.8.0","bspVersion":"2.1.0-M1","languages":["scala"],"argv":["C:\\opt\\jdk/bin/java","-Xms100m","-Xmx100m","-classpath","C:/opt/sbt/bin/sbt-launch.jar","-Dsbt.script=C:\\opt\\sbt\\bin\\sbt.bat","xsbt.boot.Boot","-bsp"]}

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -7,7 +7,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies  ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+  "org.scalatest" %% "scalatest" % "3.2.14" % "test",
   "com.github.darrenjw" %% "scala-glm" % "0.8-SNAPSHOT",
   ("org.ddahl" %% "rscala" % "3.2.19").cross(CrossVersion.for3Use2_13)
 )

--- a/examples/project/build.properties
+++ b/examples/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.5.1
+sbt.version=1.8.0
 

--- a/examples/project/plugins.sbt
+++ b/examples/project/plugins.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.12.17"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.5.1
+sbt.version=1.8.0
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.22" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6" )
 

--- a/src/main/scala/scalaglm/Glm.scala
+++ b/src/main/scala/scalaglm/Glm.scala
@@ -10,7 +10,7 @@ package scalaglm
 import breeze.linalg._
 import breeze.stats.distributions.{ Gaussian, Binomial, Poisson }
 import breeze.numerics._
-import dev.ludovic.netlib.BLAS.{ getInstance => blas }
+import dev.ludovic.netlib.blas.BLAS.{ getInstance => blas }
 
 import breeze.stats.distributions.Rand.VariableSeed.randBasis
 

--- a/src/main/scala/scalaglm/Utils.scala
+++ b/src/main/scala/scalaglm/Utils.scala
@@ -14,7 +14,7 @@ import math.Pi
 
 object Utils {
 
-  import dev.ludovic.netlib.BLAS.{ getInstance => blas }
+  import dev.ludovic.netlib.blas.BLAS.{ getInstance => blas }
 
   /**
    * Backsolve an upper-triangular linear system


### PR DESCRIPTION
The current release of `scala-glm` is not compatible with recent releases of [breeze](https://github.com/scalanlp/breeze), due to using outdated versions of some libraries.

This PR updates version strings for `breeze` compatibility.    This necessitated updating the package names for the `BLAS` package in two files.

A related PR is [rscala #30](https://github.com/dbdahl/rscala/pull/30) which was affected transitively by these changes.

Below are the symptoms of the incompatibility in the build output of my project, fixed by this PR:
<details>
<pre>
[info] compiling 3 Scala sources to C:\opt\ue\vastblue\target\scala-3.2.1\classes ...
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/C:/opt/ue/"), "apps"):
[error]    com.lihaoyi:geny _3, _2.13
[error]    org.scala-lang.modules:scala-collection-compat _3, _2.13
[error]    com.lihaoyi:sourcecode _3, _2.13
[error]    com.lihaoyi:fansi _3, _2.13
[error]    com.lihaoyi:pprint _3, _2.13
[info] done compiling
[warn] multiple main classes detected: run 'show discoveredMainClasses' to see the list
[info] :: delivering :: org.vastblue#vastblue_3;0.9.4-SNAPSHOT :: 0.9.4-SNAPSHOT :: integration :: Fri Dec 02 10:47:02 MST 2022
[info]  delivering ivy file to C:\opt\ue\vastblue\target\scala-3.2.1\ivy-0.9.4-SNAPSHOT.xml
[info]  published vastblue_3 to C:\Users\philwalk\.ivy2\local\org.vastblue\vastblue_3\0.9.4-SNAPSHOT\poms\vastblue_3.pom
[info]  published vastblue_3 to C:\Users\philwalk\.ivy2\local\org.vastblue\vastblue_3\0.9.4-SNAPSHOT\jars\vastblue_3.jar
[info]  published vastblue_3 to C:\Users\philwalk\.ivy2\local\org.vastblue\vastblue_3\0.9.4-SNAPSHOT\srcs\vastblue_3-sources.jar
[info]  published ivy to C:\Users\philwalk\.ivy2\local\org.vastblue\vastblue_3\0.9.4-SNAPSHOT\ivys\ivy.xml
########################## make cache file [C:\opt\ue\vastblueClasspath-3.cache]
[error] java.lang.RuntimeException: Conflicting cross-version suffixes in: com.lihaoyi:geny, org.scala-lang.modules:scala-collection-compat, com.lihaoyi:sourcecode, com.lihaoyi:fansi, com.lihaoyi:pprint
[error]         at scala.sys.package$.error(package.scala:30)
[error]         at sbt.librarymanagement.ConflictWarning$.processCrossVersioned(ConflictWarning.scala:39)
[error]         at sbt.librarymanagement.ConflictWarning$.apply(ConflictWarning.scala:19)
[error]         at sbt.Classpaths$.$anonfun$ivyBaseSettings$71(Defaults.scala:3203)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error]         at sbt.Execute.work(Execute.scala:291)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[error]         at java.base/java.lang.Thread.run(Thread.java:831)
[error] (apps / update) Conflicting cross-version suffixes in: com.lihaoyi:geny, org.scala-lang.modules:scala-collection-compat, com.lihaoyi:sourcecode, com.lihaoyi:fansi, com.lihaoyi:pprint
[error] Total time: 7 s, completed Dec 2, 2022, 10:47:02 AM
</pre>
</details>